### PR TITLE
Exclude .next folder in image building process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+.next


### PR DESCRIPTION
* Add `.next` folder to `.dockerignore` so that the generated folder is not included in the docker image.